### PR TITLE
add sql clients in sysbench image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN apt-get update
 
 # Install MySQL and PostgreSQL clients
-RUN apt-get update -yy && DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client mysql-client
+RUN apt-get -y install postgresql-client mysql-client
 
 RUN apt-get -y install make automake libtool pkg-config libaio-dev git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 
 RUN apt-get update
 
+# Install MySQL and PostgreSQL clients
+RUN apt-get update -yy && DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client mysql-client
+
 RUN apt-get -y install make automake libtool pkg-config libaio-dev git
 
 # For MySQL support


### PR DESCRIPTION
To simplify the sysbench related pipelines, we need to integrate the SQL clients into sysbench image to allow run SQL queries before and after sysbench operations